### PR TITLE
Replace `Syscall` with `x/sys/unix.IoctlSetWinsize`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/zyedidia/terminal
 
 go 1.19
 
-require github.com/creack/pty v1.1.18
+require (
+	github.com/creack/pty v1.1.18
+	golang.org/x/sys v0.28.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/ioctl_other.go
+++ b/ioctl_other.go
@@ -2,14 +2,6 @@
 
 package terminal
 
-import (
-	"os"
-)
-
-func ioctl(f *os.File, cmd, p uintptr) error {
-	return nil
-}
-
 func (t *VT) ptyResize() error {
 	return nil
 }

--- a/ioctl_other.go
+++ b/ioctl_other.go
@@ -1,4 +1,4 @@
-// +build plan9 nacl windows
+//go:build plan9 || nacl || windows
 
 package terminal
 

--- a/ioctl_posix.go
+++ b/ioctl_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin dragonfly solaris openbsd netbsd freebsd
+//go:build linux || darwin || dragonfly || solaris || openbsd || netbsd || freebsd
 
 package terminal
 

--- a/ioctl_posix.go
+++ b/ioctl_posix.go
@@ -3,32 +3,18 @@
 package terminal
 
 import (
-	"os"
-	"syscall"
-	"unsafe"
+	"golang.org/x/sys/unix"
 )
-
-func ioctl(f *os.File, cmd, p uintptr) error {
-	_, _, errno := syscall.Syscall(
-		syscall.SYS_IOCTL,
-		f.Fd(),
-		syscall.TIOCSWINSZ,
-		p)
-	if errno != 0 {
-		return syscall.Errno(errno)
-	}
-	return nil
-}
 
 func (t *VT) ptyResize() error {
 	if t.pty == nil {
 		return nil
 	}
-	var w struct{ row, col, xpix, ypix uint16 }
-	w.row = uint16(t.dest.rows)
-	w.col = uint16(t.dest.cols)
-	w.xpix = 16 * uint16(t.dest.cols)
-	w.ypix = 16 * uint16(t.dest.rows)
-	return ioctl(t.pty, syscall.TIOCSWINSZ,
-		uintptr(unsafe.Pointer(&w)))
+	w := &unix.Winsize{
+		Row:    uint16(t.dest.rows),
+		Col:    uint16(t.dest.cols),
+		Xpixel: 16 * uint16(t.dest.cols),
+		Ypixel: 16 * uint16(t.dest.rows),
+	}
+	return unix.IoctlSetWinsize(int(t.pty.Fd()), unix.TIOCSWINSZ, w)
 }

--- a/vt_other.go
+++ b/vt_other.go
@@ -1,5 +1,4 @@
 //go:build plan9 || nacl || windows
-// +build plan9 nacl windows
 
 package terminal
 

--- a/vt_posix.go
+++ b/vt_posix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || dragonfly || solaris || openbsd || netbsd || freebsd
-// +build linux darwin dragonfly solaris openbsd netbsd freebsd
 
 package terminal
 


### PR DESCRIPTION
There are platforms where `SYS_IOCTL` is not defined probably because libc functions have to be used. Reasons why `Syscall` cannot be used in any platform may be added or changed but they would be handled in `x/sys/unix` and Go source code, so the call is replaced in this pull request.

Small unrelated style changes were also done in other commits.

Edit: The code in the orgnanization repository only is changed, so the issues in the old fork are not closed with this pull request now.